### PR TITLE
Fix tests which need cmath operations.

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -206,6 +206,7 @@ public:
 
         // load frequently used headers
         const char* code =
+               "#include <cmath>\n" // for the missing std::sqrt
                "#include <iostream>\n"
                "#include <string>\n"
             //    "#include <DllImport.h>\n"     // defines R__EXTERN


### PR DESCRIPTION
We have several tests failing because of missing std::sqrt. ROOT used to automatically load the header files and that's why it worked. Instead we should include the relevant header files and later use PCM/PCH.