### PR TITLE
GetMethodPrototype is not used by cppyy. Mark it unused.

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1354,7 +1354,8 @@ std::string Cppyy::GetMethodSignature(TCppMethod_t method, bool show_formal_args
 
 std::string Cppyy::GetMethodPrototype(TCppMethod_t method, bool show_formal_args)
 {
-    return InterOp::GetFunctionPrototype(method, show_formal_args);
+  assert(0 && "Unused");
+  return ""; // return InterOp::GetFunctionPrototype(method, show_formal_args);
 }
 
 bool Cppyy::IsConstMethod(TCppMethod_t method)

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -278,6 +278,7 @@ namespace Cppyy {
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     RPY_EXPORTED
     std::string GetMethodSignature(TCppMethod_t, bool show_formal_args, TCppIndex_t max_args = (TCppIndex_t)-1);
+    // GetMethodPrototype is unused.
     RPY_EXPORTED
     std::string GetMethodPrototype(TCppMethod_t, bool show_formal_args);
     RPY_EXPORTED


### PR DESCRIPTION
That would help us remove the crafty implementation of GetFunctionPrototype in InterOp.