### PR TITLE
Throw an exception to signal where we still rely on qualified name lookups.

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -424,6 +424,10 @@ bool Cppyy::IsClassType(TCppType_t type) {
 }
 
 Cppyy::TCppType_t Cppyy::GetType(const std::string &name) {
+    if (name.find("::") != std::string::npos)
+        throw std::runtime_error("Calling Cppyy::GetType with qualified name '"
+                                 + name + "'\n");
+
     return InterOp::GetType(getSema(), name);
 }
 


### PR DESCRIPTION


This patch should help find the places where we should split the lookups into multiple unqualified ones.