### PR TITLE
Do not depend on libcling but solely on InterOp.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
               ../llvm
         cmake --build . --target clang --parallel $(nproc --all)
         cmake --build . --target cling --parallel $(nproc --all)
-        cmake --build . --target libcling --parallel $(nproc --all)
         # Now build gtest.a and gtest_main for InterOp to run its tests.
         cmake --build . --target gtest_main --parallel $(nproc --all)
         cd ../../
@@ -138,28 +137,27 @@ jobs:
         CLING_BUILD_DIR="$(realpath cling/build)"
         CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include"
         git clone https://github.com/compiler-research/InterOp.git
+        export INTEROP_DIR=$PWD/python/cppyy_backend/
         cd InterOp
-        pwd
-        mkdir build install
-        export INTEROP_DIR="$(realpath install)"
-        cd build
-        cmake -DUSE_CLING=ON -DCling_DIR=$LLVM_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$INTEROP_DIR ../
-        #cmake --build . --target check-interop --parallel $(nproc --all)
-        cmake --build . --target install --parallel $(nproc --all)
+        mkdir build && cd build
+        export INTEROP_BUILD_DIR=$PWD
+        cmake -DBUILD_SHARED_LIBS=ON -DUSE_CLING=ON -DCling_DIR=$LLVM_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$INTEROP_DIR ../
+        cmake --build . --parallel $(nproc --all)
         cd ../..
         # We need INTEROP_DIR, LLVM_BUILD_DIR and CPLUS_INCLUDE_PATH later
         echo "INTEROP_DIR=$INTEROP_DIR" >> $GITHUB_ENV
+        echo "INTEROP_BUILD_DIR=$INTEROP_BUILD_DIR" >> $GITHUB_ENV
         echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
         echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
     - name: Build and Install cppyy-backend on Linux
       if: runner.os == 'Linux'
       run: |
         # Install cppyy-backend
-        mkdir python/cppyy_backend/lib build && cd build
+        mkdir -p python/cppyy_backend/lib build && cd build
+        (cd $INTEROP_BUILD_DIR && cmake --build . --target install --parallel $(nproc --all))
         cmake -DInterOp_DIR=$INTEROP_DIR ..
         cmake --build . --parallel $(nproc --all)
         cp libcppyy-backend.so ../python/cppyy_backend/lib/
-        cp $LLVM_BUILD_DIR/lib/libcling.so ../python/cppyy_backend/lib/
         #
         cd ../python
         export CB_PYTHON_DIR=$PWD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,6 @@ add_library(cppyy-backend SHARED
 target_include_directories(cppyy-backend PRIVATE clingwrapper/src)
 
 
-add_library(libInterOp IMPORTED STATIC GLOBAL)
-
-set(_interop_static_archive_name ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}${CMAKE_STATIC_LIBRARY_PREFIX}clangInterOp${CMAKE_STATIC_LIBRARY_SUFFIX})
-if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-    set(_interop_byproducts ${_interop_static_archive_name})
-endif()
-
 if(DEFINED InterOp_DIR)
     set(_interop_install_dir ${InterOp_DIR})
 else()
@@ -70,33 +63,4 @@ endif()
 set_source_files_properties(clingwrapper/src/clingwrapper.cxx
   PROPERTIES COMPILE_DEFINITIONS "INTEROP_DIR=\"${_interop_install_dir}\"")
 
-set_property(TARGET libInterOp PROPERTY IMPORTED_LOCATION ${_interop_install_dir}/lib/${_interop_static_archive_name})
-
-if (APPLE)
-set(_interop_link_flags -Wl,-force_load $<TARGET_FILE:libInterOp> -Wl)
-elseif(MSVC)
-set(_interop_link_flags "-WHOLEARCHIVE:" $<TARGET_FILE:libInterOp>)
-else()
-set(_interop_link_flags -Wl,--whole-archive $<TARGET_FILE:libInterOp> -Wl,--no-whole-archive)
-endif()
-target_link_libraries(cppyy-backend PUBLIC ${_interop_link_flags})
-
-add_dependencies(cppyy-backend libInterOp)
-
-# set(CLING_LIBS
-#     ${PROJECT_SOURCE_DIR}/../cling/builddir/lib/libclingInterpreter.a
-#     # clangAST
-#     # clangBasic
-#     # clangLex
-# )
-
 target_include_directories(cppyy-backend PUBLIC ${_interop_install_dir}/include)
-
-# target_link_libraries(cppyy-backend ${CLING_LIBS})
-# target_link_libraries(cppyy-backend ${PROJECT_SOURCE_DIR}/../cling/builddir/lib/libcling.so)
-
-# get_cmake_property(_variableNames VARIABLES)
-# list (SORT _variableNames)
-# foreach (_variableName ${_variableNames})
-#     message(STATUS "${_variableName}=${${_variableName}}")
-# endforeach()

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ cmake -DLLVM_ENABLE_PROJECTS=clang                \
     ../llvm
 cmake --build . --target clang --parallel $(nproc --all)
 cmake --build . --target cling --parallel $(nproc --all)
-cmake --build . --target libcling --parallel $(nproc --all)
 cmake --build . --target gtest_main --parallel $(nproc --all)
 ```
 
@@ -39,24 +38,22 @@ cd ../
 
 ### Install InterOp
 
-Clone the InterOp repo. Build it using cling and install:
+Clone the InterOp repo. Build it using cling and install. Note down the path to
+InterOp install directory. This will be referred to as `INTEROP_DIR`:
+
+```
+export INTEROP_DIR=$PWD/cppyy-backend/python/cppyy_backend
+```
 
 ```
 git clone https://github.com/compiler-research/InterOp.git
 cd InterOp
 mkdir build install && cd build
-cmake -DUSE_CLING=ON -DCling_DIR=$LLVM_DIR/build -DCMAKE_INSTALL_PREFIX=$PWD/../install ..
+INTEROP_BUILD_DIR=$(PWD)
+cmake -DBUILD_SHARED_LIBS=ON -DUSE_CLING=ON -DCling_DIR=$LLVM_DIR/build -DCMAKE_INSTALL_PREFIX=$INTEROP_DIR ..
 cmake --build . --target install
 ```
 
-Note down the path to InterOp install directory. This will be referred to as
-`INTEROP_DIR`:
-
-```
-cd ../install
-export INTEROP_DIR=$PWD
-cd ../..
-```
 
 ### Install cppyy-backend
 
@@ -66,10 +63,12 @@ Clone the repo, build it and copy library files into `python/cppyy-backend` dire
 git clone https://github.com/compiler-research/cppyy-backend.git
 cd cppyy-backend
 mkdir python/cppyy_backend/lib build && cd build
+# Install InterOp first to appear in python/cppyy_backend/
+(cd $INTEROP_BUILD_DIR --build . --target install)
+
 cmake -DInterOp_DIR=$INTEROP_DIR ..
 cmake --build .
 cp libcppyy-backend.so ../python/cppyy_backend/lib/
-cp $LLVM_DIR/build/lib/libcling.so ../python/cppyy_backend/lib/
 ```
 
 Note down the path to `cppyy-backend/python` directory as "CB_PYTHON_DIR":

--- a/python/cppyy_backend/loader.py
+++ b/python/cppyy_backend/loader.py
@@ -44,12 +44,12 @@ def _load_helper(bkname):
             pkgpath = os.path.dirname(__file__)
         elif os.path.basename(pkgpath) in ['lib', 'bin']:
             pkgpath = os.path.dirname(pkgpath)
-        for dep in ['libcling']:
+        for dep in ['libclangInterOp']:
             for loc in ['lib', 'bin']:
                 fpath = os.path.join(pkgpath, loc, dep+soext)
                 if os.path.exists(fpath):
                     ldtype = ctypes.RTLD_GLOBAL
-                    #  if dep == 'libCling': ldtype = ctypes.RTLD_LOCAL
+                    #  if dep == 'libclangInterOp': ldtype = ctypes.RTLD_LOCAL
                     ctypes.CDLL(fpath, ldtype)
                     break
         return ctypes.CDLL(os.path.join(pkgpath, 'lib', bkname), ctypes.RTLD_GLOBAL), errors


### PR DESCRIPTION
This patch builds a shared object which includes all necessary llvm symbols just like libcling did. That would pave our way to enable clang-repl based support in the cppyy-backend.