### PR TITLE
Return the error set.

### DIFF
--- a/python/cppyy_backend/loader.py
+++ b/python/cppyy_backend/loader.py
@@ -44,7 +44,7 @@ def _load_helper(bkname):
 
  # normal load, allowing for user overrides of LD_LIBRARY_PATH
     try:
-        return ctypes.CDLL(bkname, ctypes.RTLD_GLOBAL)
+        return ctypes.CDLL(bkname, ctypes.RTLD_GLOBAL), errors
     except OSError as e:
         errors.add(str(e))
 


### PR DESCRIPTION
This fixes a subtle error when libcppyy-backend has all of its dependencies loaded and it exits successfully at the first time.

In that case python thinks that the cdll object is the error set and tries to iterate it causing a error:

```
Traceback (most recent call last):
  File "/opt/conda/envs/.venv/lib/python3.10/site-packages/cppyy/__init__.py", line 80, in <module>
    from ._cpython_cppyy import *
  File "/opt/conda/envs/.venv/lib/python3.10/site-packages/cppyy/_cpython_cppyy.py", line 21, in <module>
    c = loader.load_cpp_backend()
  File "/home/jovyan/cppyy-backend/python/cppyy_backend/loader.py", line 99, in load_cpp_backend
    c, err2 = _load_helper(name)
  File "/opt/conda/envs/.venv/lib/python3.10/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
TypeError: function name must be string, bytes object or integer
```