### PR TITLE
Macos apple silicon fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(cppyy-backend)
 include(ExternalProject)
+include(CMakeSystemSpecificInformation)
 
 set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
 set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
@@ -63,5 +64,9 @@ endif()
 
 set_source_files_properties(clingwrapper/src/clingwrapper.cxx
   PROPERTIES COMPILE_DEFINITIONS "CPPINTEROP_DIR=\"${_interop_install_dir}\"")
+
+# Link to CppInterOp library. Without this can't build on MacOS due to undefined symbols
+target_link_libraries(cppyy-backend ${_interop_install_dir}/lib/libclangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX})
+
 
 target_include_directories(cppyy-backend PUBLIC ${_interop_install_dir}/include)

--- a/clingwrapper/setup.py
+++ b/clingwrapper/setup.py
@@ -24,8 +24,10 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 if 'win32' in sys.platform:
     soext = '.dll'
-else:
+elif 'linux' in sys.platform:
     soext = '.so'
+else:
+    soext = '.dylib'
 
 #
 # platform-dependent helpers

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -171,11 +171,31 @@ public:
             Interp = existingInterp;
         }
         else {
+	  #ifdef __arm64__
+	    #ifdef __APPLE__
+	      //If on apple silicon don't use -march=native
+	      std::vector <const char *> InterpArgs({"-std=c++17"});
+	    #else
+	      std::vector <const char *> InterpArgs({"-std=c++17", "-march=native"});
+	    #endif
+	  #else 
             std::vector <const char *> InterpArgs({"-std=c++17", "-march=native"});
-            char *InterpArgString = getenv("CPPINTEROP_EXTRA_INTERPRETER_ARGS");
-            if (InterpArgString)
-               push_tokens_from_string(InterpArgString, InterpArgs);
-            Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
+	  #endif
+	  char *InterpArgString = getenv("CPPINTEROP_EXTRA_INTERPRETER_ARGS");
+
+	  if (InterpArgString)
+             push_tokens_from_string(InterpArgString, InterpArgs);
+	    
+	  #ifdef __arm64__
+	    #ifdef __APPLE__
+	      //If on apple silicon don't use -march=native
+	      Interp = Cpp::CreateInterpreter({"-std=c++17"});
+	    #else
+	      Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
+	    #endif
+	  #else
+	     Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
+          #endif
         }
 
         // fill out the builtins

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -171,31 +171,32 @@ public:
             Interp = existingInterp;
         }
         else {
-	  #ifdef __arm64__
-	    #ifdef __APPLE__
-	      //If on apple silicon don't use -march=native
-	      std::vector <const char *> InterpArgs({"-std=c++17"});
-	    #else
-	      std::vector <const char *> InterpArgs({"-std=c++17", "-march=native"});
-	    #endif
-	  #else 
+#ifdef __arm64__
+#ifdef __APPLE__
+            // If on apple silicon don't use -march=native
+            std::vector<const char *> InterpArgs({"-std=c++17"});
+#else
+            std::vector<const char *> InterpArgs(
+                {"-std=c++17", "-march=native"});
+#endif
+#else
             std::vector <const char *> InterpArgs({"-std=c++17", "-march=native"});
-	  #endif
-	  char *InterpArgString = getenv("CPPINTEROP_EXTRA_INTERPRETER_ARGS");
+#endif
+            char *InterpArgString = getenv("CPPINTEROP_EXTRA_INTERPRETER_ARGS");
 
-	  if (InterpArgString)
-             push_tokens_from_string(InterpArgString, InterpArgs);
-	    
-	  #ifdef __arm64__
-	    #ifdef __APPLE__
-	      //If on apple silicon don't use -march=native
-	      Interp = Cpp::CreateInterpreter({"-std=c++17"});
-	    #else
-	      Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
-	    #endif
-	  #else
-	     Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
-          #endif
+            if (InterpArgString)
+              push_tokens_from_string(InterpArgString, InterpArgs);
+
+#ifdef __arm64__
+#ifdef __APPLE__
+            // If on apple silicon don't use -march=native
+            Interp = Cpp::CreateInterpreter({"-std=c++17"});
+#else
+            Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
+#endif
+#else
+            Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"});
+#endif
         }
 
         // fill out the builtins

--- a/python/cppyy_backend/loader.py
+++ b/python/cppyy_backend/loader.py
@@ -19,8 +19,10 @@ import warnings
 
 if 'win32' in sys.platform:
     soext = '.dll'
-else:
+elif 'linux' in sys.platform:
     soext = '.so'
+else:
+    soext = '.dylib'
 
 soabi = sysconfig.get_config_var("SOABI")
 soext2 = sysconfig.get_config_var("EXT_SUFFIX")


### PR DESCRIPTION
Add .dylib option when building on MacOS
Disabled use of -march=native when on Apple Silicon
Link to CppInterOp (without this on MacOS you get undefined symbols error when building)

Copy of pull request https://github.com/compiler-research/cppyy-backend/pull/88 which had Github CI issues

@vgvassilev Here is the branch containing the fixes for apple silicon builds