### PR TITLE
Remove redundant jobs from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,37 +21,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-17
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '17'
-            cling: Off
-            cppyy: Off
           - name: ubu22-x86-gcc12-clang-repl-17-cppyy
             os: ubuntu-22.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc9-clang-repl-16
-            os: ubuntu-22.04
-            compiler: gcc-9
-            clang-runtime: '16'
-            cling: Off
-            cppyy: Off
           - name: ubu22-x86-gcc9-clang-repl-16-cppyy
             os: ubuntu-22.04
             compiler: gcc-9
             clang-runtime: '16'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc9-clang13-cling
-            os: ubuntu-22.04
-            compiler: gcc-9
-            clang-runtime: '13'
-            cling: On
-            cling-version: '1.0'
-            cppyy: Off
           - name: ubu22-x86-gcc9-clang13-cling-cppyy
             os: ubuntu-22.04
             compiler: gcc-9
@@ -140,37 +121,18 @@ jobs:
           #  cling: On
           #  cling-version: '1.0'
           #  cppyy: On
-          - name: osx13-x86-clang-clang-repl-17
-            os: macos-13
-            compiler: clang
-            clang-runtime: '17'
-            cling: Off
-            cppyy: Off
           - name: osx13-x86-clang-clang-repl-17-cppyy
             os: macos-13
             compiler: clang
             clang-runtime: '17'
             cling: Off
             cppyy: On
-          - name: osx13-x86-clang-clang-repl-16
-            os: macos-13
-            compiler: clang
-            clang-runtime: '16'
-            cling: Off
-            cppyy: Off
           - name: osx13-x86-clang-clang-repl-16-cppyy
             os: macos-13
             compiler: clang
             clang-runtime: '16'
             cling: Off
             cppyy: On
-          - name: osx13-x86-clang-clang13-cling
-            os: macos-13
-            compiler: clang
-            clang-runtime: '13'
-            cling: On
-            cling-version: '1.0'
-            cppyy: Off
           - name: osx13-x86-clang-clang13-cling-cppyy
             os: macos-13
             compiler: clang


### PR DESCRIPTION
@vgvassilev This PR removes redundant jobs from this ci. They're only there due to a copy and pasting of the ci from CppInterOp a while back. Can you merge? 