### PR TITLE
Add canonical type interface for method arguments

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1395,6 +1395,14 @@ std::string Cppyy::GetMethodArgTypeAsString(TCppMethod_t method, TCppIndex_t iar
         Cpp::GetFunctionArgType(method, iarg));
 }
 
+std::string Cppyy::GetMethodArgCanonTypeAsString(TCppMethod_t method, TCppIndex_t iarg)
+{
+    return
+    Cpp::GetTypeAsString(
+        Cpp::GetCanonicalType(
+            Cpp::GetFunctionArgType(method, iarg)));
+}
+
 std::string Cppyy::GetMethodArgDefault(TCppMethod_t method, TCppIndex_t iarg)
 {
     if (!method)

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -284,6 +284,8 @@ namespace Cppyy {
     RPY_EXPORTED
     std::string GetMethodArgTypeAsString(TCppMethod_t method, TCppIndex_t iarg);
     RPY_EXPORTED
+    std::string GetMethodArgCanonTypeAsString(TCppMethod_t method, TCppIndex_t iarg);
+    RPY_EXPORTED
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     RPY_EXPORTED
     std::string GetMethodSignature(TCppMethod_t, bool show_formal_args, TCppIndex_t max_args = (TCppIndex_t)-1);


### PR DESCRIPTION
This is part of the fix in `CPyCppyy/Dispatcher.cxx` where the old usages are replaced in favour of the canonical types.