### PR TITLE
[ci] Update the CI to follow other repositories in running valgrind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,13 +720,10 @@ jobs:
         if [[ "${{ matrix.os }}" == macos-* ]]; then
         echo "Skipping Valgrind checks on macOS"
         else
-            if [[ "${{ matrix.clang-runtime }}" == "17" ]]; then
-                echo "Valgrind reports true for clang-runtime 17, due to memory leaks with LLVM"
-                valgrind --show-error-list=yes --error-exitcode=1 --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v || true
-            else
-                echo "Running valgrind on passing tests"
-                valgrind --show-error-list=yes --error-exitcode=1 --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v
-            fi
+            echo "Running valgrind on passing tests"
+            CLANG_VERSION="${{ matrix.clang-runtime }}"
+            SUPPRESSION_FILE="../etc/clang${CLANG_VERSION}-valgrind.supp"
+            valgrind --show-error-list=yes --error-exitcode=1 --track-origins=yes --suppressions="${SUPPRESSION_FILE}" --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v
         fi
         export RETCODE=+$?
         echo ::endgroup::


### PR DESCRIPTION
The valgrind CI commands were never updated to the new style on this repo and lags the other ones. It has been the same since llvm18 and 19, this now  fixes the two jobs that have been failing on master. 