### PR TITLE
fix parsing template params

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1497,7 +1497,7 @@ Cppyy::TCppMethod_t Cppyy::GetMethodTemplate(
     if (name.find('<') != std::string::npos) {
         pureName = name.substr(0, name.find('<'));
         size_t start = name.find('<');
-        size_t end = name.find('>');
+        size_t end = name.rfind('>');
         explicit_params = name.substr(start + 1, end - start - 1);
     }
 


### PR DESCRIPTION
Fixes [`test03_replacement_of_eq`](https://github.com/Vipul-Cariappa/cppyy-compiler-research/blob/ee71db3b0e918ae1eaf89ccd5252d904b0f0d153/test/test_stltypes.py#L1092-L1093)