### PR TITLE
fix `Cppyy::GetMethodSignature` to return list of argument type

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1412,26 +1412,22 @@ std::string Cppyy::GetMethodArgDefault(TCppMethod_t method, TCppIndex_t iarg)
 
 std::string Cppyy::GetMethodSignature(TCppMethod_t method, bool show_formal_args, TCppIndex_t max_args)
 {
-    if (Cppyy::IsTemplatedMethod(method)) {
-        std::ostringstream sig;
-        sig << "(";
-        int nArgs = GetMethodNumArgs(method);
-        if (max_args != (TCppIndex_t)-1) nArgs = std::min(nArgs, (int)max_args);
-        for (int iarg = 0; iarg < nArgs; ++iarg) {
-            sig << Cppyy::GetMethodArgTypeAsString(method, iarg);
-            if (show_formal_args) {
-                const char* argname = Cppyy::GetMethodArgName(method, iarg).c_str();
-                if (argname && argname[0] != '\0') sig << " " << argname;
-                const char* defvalue = Cppyy::GetMethodArgDefault(method, iarg).c_str();
-                if (defvalue && defvalue[0] != '\0') sig << " = " << defvalue;
-            }
-            if (iarg != nArgs-1) sig << (show_formal_args ? ", " : ",");
+    std::ostringstream sig;
+    sig << "(";
+    int nArgs = GetMethodNumArgs(method);
+    if (max_args != (TCppIndex_t)-1) nArgs = std::min(nArgs, (int)max_args);
+    for (int iarg = 0; iarg < nArgs; ++iarg) {
+        sig << Cppyy::GetMethodArgTypeAsString(method, iarg);
+        if (show_formal_args && Cppyy::IsTemplatedMethod(method)) {
+            std::string argname = Cppyy::GetMethodArgName(method, iarg);
+            if (!argname.empty()) sig << " " << argname;
+            std::string defvalue = Cppyy::GetMethodArgDefault(method, iarg);
+            if (!defvalue.empty()) sig << " = " << defvalue;
         }
-        sig << ")";
-        return sig.str();
+        if (iarg != nArgs-1) sig << (show_formal_args ? ", " : ",");
     }
-
-    else return Cpp::GetFunctionSignature(method);
+    sig << ")";
+    return sig.str();
 }
 
 std::string Cppyy::GetMethodPrototype(TCppMethod_t method, bool show_formal_args)


### PR DESCRIPTION
fixes 2 tests in cppyy

`test_doc_features.py::TestADVERTISED::test01_reduction_of_overloads` and `test_overloads.py::TestOVERLOADS::test02_class_based_overloads_explicit_resolution`