### PR TITLE
fix: handle `std::byte` as a special case

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -448,7 +448,8 @@ Cppyy::TCppType_t Cppyy::ResolveType(TCppType_t type) {
     Cppyy::TCppType_t canonType = Cpp::GetCanonicalType(type);
 
     if (Cpp::IsEnumType(canonType)) {
-        return Cpp::GetIntegerTypeFromEnumType(canonType);
+        if (Cppyy::GetTypeAsString(type) != "std::byte")
+            return Cpp::GetIntegerTypeFromEnumType(canonType);
     }
 
     return canonType;


### PR DESCRIPTION
Fixes:
`test_datatypes.py::TestDATATYPES::test04_class_read_access` and `test_datatypes.py::TestDATATYPES::test05_class_data_write_access`
with https://github.com/compiler-research/CPyCppyy/pull/78