### PR TITLE
Prefix InterOp cmake options

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -477,8 +477,8 @@ jobs:
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         if [[ "${cling_on}" == "ON" ]]; then
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
-                -DUSE_CLING=ON                                  \
-                -DUSE_REPL=OFF                                  \
+                -DCPPINTEROP_USE_CLING=ON                                  \
+                -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -440,8 +440,8 @@ jobs:
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         if [[ "${cling_on}" == "ON" ]]; then
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
-                -DUSE_CLING=ON                                  \
-                -DUSE_REPL=OFF                                  \
+                -DCPPINTEROP_USE_CLING=ON                                  \
+                -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -377,8 +377,8 @@ jobs:
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}    `
-                -DUSE_CLING=ON                                  `
-                -DUSE_REPL=OFF                                  `
+                -DCPPINTEROP_USE_CLING=ON                                  `
+                -DCPPINTEROP_USE_REPL=OFF                                  `
                 -DCling_DIR="$env:LLVM_BUILD_DIR\tools\cling"   `
                 -DLLVM_DIR="$env:LLVM_BUILD_DIR" `
                 -DLLVM_ENABLE_WERROR=On                          `

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -598,8 +598,8 @@ jobs:
         export CPPINTEROP_BUILD_DIR=$PWD
         if [[ "${cling_on}" == "ON" ]]; then
           emcmake cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
-                -DUSE_CLING=ON                                  \
-                -DUSE_REPL=OFF                                  \
+                -DCPPINTEROP_USE_CLING=ON                                  \
+                -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCMAKE_PREFIX_PATH=$PREFIX                     \
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ if(DEFINED CppInterOp_DIR)
 else()
     set(_interop_install_dir ${CMAKE_BINARY_DIR}/CppInterOp/install)
 
-    if(DEFINED USE_CLING)
-        list(APPEND _interop_cmake_args "-DUSE_CLING=${USE_CLING}")
+    if(DEFINED CPPINTEROP_USE_CLING)
+        list(APPEND _interop_cmake_args "-DCPPINTEROP_USE_CLING=${CPPINTEROP_USE_CLING}")
     endif()
 
     if(DEFINED Cling_DIR)

--- a/README.md
+++ b/README.md
@@ -181,22 +181,22 @@ cd CppInterOp\build\
 
 Now if you want to build CppInterOp with Clang-REPL then execute the following commands on Linux and MacOS
 ```
-cmake -DBUILD_SHARED_LIBS=ON -DUSE_CLING=Off -DUSE_REPL=ON -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
+cmake -DBUILD_SHARED_LIBS=ON -DCPPINTEROP_USE_CLING=Off -DCPPINTEROP_USE_REPL=ON -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
 cmake --build . --target install --parallel $(nproc --all)
 ```
 and
 ```
-cmake -DUSE_CLING=Off -DUSE_REPL=ON -DLLVM_DIR=$LLVM_DIR\build\lib\cmake\llvm -DClang_DIR=$LLVM_DIR\build\lib\cmake\clang -DCMAKE_INSTALL_PREFIX=$env:CPPINTEROP_DIR ..
+cmake -DCPPINTEROP_USE_CLING=Off -DCPPINTEROP_USE_REPL=ON -DLLVM_DIR=$LLVM_DIR\build\lib\cmake\llvm -DClang_DIR=$LLVM_DIR\build\lib\cmake\clang -DCMAKE_INSTALL_PREFIX=$env:CPPINTEROP_DIR ..
 cmake --build . --target install --parallel $env:ncpus
 ```
 on Windows. If alternatively you would like to install CppInterOp with Cling then execute the following commands on Linux and MacOS
 ```
-cmake -DBUILD_SHARED_LIBS=ON -DUSE_CLING=ON -DUSE_REPL=Off -DCling_DIR=$LLVM_DIR/build/tools/cling -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
+cmake -DBUILD_SHARED_LIBS=ON -DCPPINTEROP_USE_CLING=ON -DCPPINTEROP_USE_REPL=Off -DCling_DIR=$LLVM_DIR/build/tools/cling -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
 cmake --build . --target install --parallel $(nproc --all)
 ```
 and
 ```
-cmake -DUSE_CLING=ON -DUSE_REPL=Off -DCling_DIR=$LLVM_DIR\build\tools\cling -DLLVM_DIR=$LLVM_DIR\build\lib\cmake\llvm -DClang_DIR=$LLVM_DIR\build\lib\cmake\clang -DCMAKE_INSTALL_PREFIX=$env:CPPINTEROP_DIR ..
+cmake -DCPPINTEROP_USE_CLING=ON -DCPPINTEROP_USE_REPL=Off -DCling_DIR=$LLVM_DIR\build\tools\cling -DLLVM_DIR=$LLVM_DIR\build\lib\cmake\llvm -DClang_DIR=$LLVM_DIR\build\lib\cmake\clang -DCMAKE_INSTALL_PREFIX=$env:CPPINTEROP_DIR ..
 cmake --build . --target install --parallel $env:ncpus
 ```
 


### PR DESCRIPTION
Based on the change in CppInterOp: https://github.com/compiler-research/CppInterOp/pull/505 that prefixes the build option with `CPPINTEROP`