### PR TITLE
Improve operator resolution

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1662,7 +1662,7 @@ Cppyy::TCppMethod_t Cppyy::GetGlobalOperator(
             else
                 return nullptr;
         }
-        Cppyy::TCppMethod_t cppmeth = Cpp::BestTemplateFunctionMatch(
+        Cppyy::TCppMethod_t cppmeth = Cpp::BestOverloadFunctionMatch(
             unresolved_candidate_methods, {}, arg_types);
         if (cppmeth)
             return cppmeth;

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1490,8 +1490,9 @@ Cppyy::TCppMethod_t Cppyy::GetMethodTemplate(
         size_t start = name.find('<');
         size_t end = name.rfind('>');
         explicit_params = name.substr(start + 1, end - start - 1);
-    } else
+    } else {
         pureName = name;
+    }
 
     std::vector<Cppyy::TCppMethod_t> unresolved_candidate_methods;
     Cpp::GetClassTemplatedMethods(pureName, scope,

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -314,7 +314,9 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppMethod_t GetMethodTemplate(
         TCppScope_t scope, const std::string& name, const std::string& proto);
-
+    RPY_EXPORTED
+    void GetClassOperators(Cppyy::TCppScope_t klass, const std::string& opname,
+                           std::vector<TCppScope_t>& operators);
     RPY_EXPORTED
     TCppMethod_t  GetGlobalOperator(
         TCppType_t scope, const std::string& lc, const std::string& rc, const std::string& op);


### PR DESCRIPTION
`GetMethodTemplate` now also checks for operators methods using `GetClassOperators`
`GetGlobalOperator` can now handle templated types

Fixes 2 tests. Along with https://github.com/compiler-research/CppInterOp/pull/509, fixes 3 tests.