### PR TITLE
while instantiating template use non reference types

### DIFF
--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -88,8 +88,9 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppType_t GetType(const std::string &name, bool enable_slow_lookup = false);
     RPY_EXPORTED
-    bool AppendTypesSlow(const std::string &name,
-                         std::vector<Cpp::TemplateArgInfo>& types);
+    bool AppendTypesSlow(const std::string& name,
+                         std::vector<Cpp::TemplateArgInfo>& types,
+                         bool no_reference = false);
     RPY_EXPORTED
     TCppType_t GetComplexType(const std::string &element_type);
     RPY_EXPORTED


### PR DESCRIPTION
Fixes 2 issues.

Not sure in what order this PR should be merged. That is, this PR maybe dependent on the compiler-research/CppInterOp#511 and https://github.com/compiler-research/CPyCppyy/pull/83. So I will keep it as draft for now.