### PR TITLE
Add `GetTemplatedMethods` to simplify proxy creation

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1429,6 +1429,11 @@ bool Cppyy::IsConstMethod(TCppMethod_t method)
     return Cpp::IsConstMethod(method);
 }
 
+void Cppyy::GetTemplatedMethods(TCppScope_t scope, std::vector<Cppyy::TCppMethod_t> &methods)
+{
+    Cpp::GetFunctionTemplatedDecls(scope, methods);
+}
+
 Cppyy::TCppIndex_t Cppyy::GetNumTemplatedMethods(TCppScope_t scope, bool accept_namespace)
 {
     std::vector<Cppyy::TCppMethod_t> mc;
@@ -1446,21 +1451,6 @@ std::string Cppyy::GetTemplatedMethodName(TCppScope_t scope, TCppIndex_t imeth)
     return "";
 }
 
-//
-// bool Cppyy::IsTemplatedConstructor(TCppScope_t scope, TCppIndex_t imeth)
-// {
-//     if (scope == (TCppScope_t)GLOBAL_HANDLE)
-//         return false;
-//
-//     TClassRef& cr = type_from_handle(scope);
-//     if (cr.GetClass()) {
-//         TFunctionTemplate* f = (TFunctionTemplate*)cr->GetListOfFunctionTemplates(false)->At((int)imeth);
-//         return f->ExtraProperty() & kIsConstructor;
-//     }
-//
-//     return false;
-// }
-//
 bool Cppyy::ExistsMethodTemplate(TCppScope_t scope, const std::string& name)
 {
     return Cpp::ExistsFunctionTemplate(name, scope);

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -300,13 +300,13 @@ namespace Cppyy {
     std::string GetMethodPrototype(TCppMethod_t, bool show_formal_args);
     RPY_EXPORTED
     bool        IsConstMethod(TCppMethod_t);
-
+// // Templated method/function reflection information ------------------------------------
+    RPY_EXPORTED
+    void GetTemplatedMethods(TCppScope_t scope, std::vector<TCppMethod_t> &methods);
     RPY_EXPORTED
     TCppIndex_t GetNumTemplatedMethods(TCppScope_t scope, bool accept_namespace = false);
     RPY_EXPORTED
     std::string GetTemplatedMethodName(TCppScope_t scope, TCppIndex_t imeth);
-    RPY_EXPORTED
-    bool        IsTemplatedConstructor(TCppScope_t scope, TCppIndex_t imeth) { assert(0 && "IsTemplatedConstructor"); return 0; }
     RPY_EXPORTED
     bool        ExistsMethodTemplate(TCppScope_t scope, const std::string& name);
     RPY_EXPORTED


### PR DESCRIPTION
This allows CPyCppyy to no longer use index based interfaces to retrieve template method info. Deprecate `IsTemplatedConstructor`