### PR TITLE
clingwrapper - include dlfcn.h only on unix

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1,4 +1,4 @@
-#ifndef WIN32
+#ifndef _WIN32
 #ifndef _CRT_SECURE_NO_WARNINGS
 // silence warnings about getenv, strncpy, etc.
 #define _CRT_SECURE_NO_WARNINGS
@@ -10,7 +10,9 @@
 #include "cpp_cppyy.h"
 #include "callcontext.h"
 
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 
 // Standard
 #include <assert.h>


### PR DESCRIPTION
This is a POSIX only header, and should be included only on unix platforms