### PR TITLE
cast arg type from ints to doubles and resolve operators

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -246,6 +246,7 @@ public:
         // load frequently used headers
         const char* code =
                "#include <algorithm>\n"
+               "#include <numeric>\n"
                "#include <complex>\n"
                "#include <iostream>\n"
                "#include <string.h>\n" // for strcpy
@@ -1734,6 +1735,20 @@ Cppyy::TCppMethod_t Cppyy::GetGlobalOperator(
             unresolved_candidate_methods, {}, arg_types);
         if (cppmeth)
             return cppmeth;
+    }
+    {
+        // we are trying to do a madeup IntegralToFloating implicit cast emulating clang
+        bool flag = false;
+        if (rc_type == "int") {
+            rc_type = "double";
+            flag = true;
+        }
+        if (lc_type == "int") {
+            lc_type = "double";
+            flag = true;
+        }
+        if (flag)
+            return GetGlobalOperator(scope, lc_type, rc_type, opname);
     }
     return nullptr;
 }


### PR DESCRIPTION
If operator resolution fails with the given argument types, we cast ints to doubles and try again.

---

Enable a test.