### PR TITLE
Add Cppyy::IsStaticTemplate, part of syncup with wlav/cppyy-backend

### DIFF
--- a/clingwrapper/src/capi.h
+++ b/clingwrapper/src/capi.h
@@ -109,6 +109,8 @@ extern "C" {
     RPY_EXPORTED
     int cppyy_is_namespace(cppyy_scope_t scope);
     RPY_EXPORTED
+    int cppyy_is_static_template(cppyy_scope_t scope, const char* name);
+    RPY_EXPORTED
     int cppyy_is_template(const char* template_name);
     RPY_EXPORTED
     int cppyy_is_abstract(cppyy_type_t type);

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1599,6 +1599,13 @@ bool Cppyy::IsTemplatedMethod(TCppMethod_t method)
     return Cpp::IsTemplatedFunction(method);
 }
 
+bool Cppyy::IsStaticTemplate(TCppScope_t scope, const std::string& name)
+{
+    if (Cpp::TCppFunction_t tf = GetMethodTemplate(scope, name, ""))
+        return Cpp::IsStaticMethod(tf);
+    return false;
+}
+
 Cppyy::TCppMethod_t Cppyy::GetMethodTemplate(
     TCppScope_t scope, const std::string& name, const std::string& proto)
 {

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -318,6 +318,8 @@ namespace Cppyy {
     RPY_EXPORTED
     bool        IsTemplatedMethod(TCppMethod_t method);
     RPY_EXPORTED
+    bool        IsStaticTemplate(TCppScope_t scope, const std::string& name);
+    RPY_EXPORTED
     TCppMethod_t GetMethodTemplate(
         TCppScope_t scope, const std::string& name, const std::string& proto);
     RPY_EXPORTED


### PR DESCRIPTION
Based on https://github.com/wlav/cppyy-backend/commit/240ea541a50ca54105b429f3665c76b8ae53e9f2, required for https://github.com/wlav/CPyCppyy/commit/c6d623a43f346b7703032df166fb2ca788456526 in CPyCppyy