### PR TITLE
Expose GetReferencedType and GetPointerType

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -500,6 +500,14 @@ Cppyy::TCppType_t Cppyy::GetRealType(TCppType_t type) {
     return Cpp::GetUnderlyingType(type);
 }
 
+Cppyy::TCppType_t Cppyy::GetPointerType(TCppType_t type) {
+  return Cpp::GetPointerType(type);
+}
+
+Cppyy::TCppType_t Cppyy::GetReferencedType(TCppType_t type, bool rvalue) {
+  return Cpp::GetReferencedType(type, rvalue);
+}
+
 bool Cppyy::IsClassType(TCppType_t type) {
     return Cpp::IsRecordType(type);
 }

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -84,6 +84,10 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppType_t GetRealType(TCppType_t type);
     RPY_EXPORTED
+    TCppType_t GetPointerType(TCppType_t type);
+    RPY_EXPORTED
+    TCppType_t GetReferencedType(TCppType_t type, bool rvalue = false);
+    RPY_EXPORTED
     std::string ResolveEnum(TCppScope_t enum_scope);
     RPY_EXPORTED
     bool IsClassType(TCppType_t type);


### PR DESCRIPTION
Required in CPyCppyy/Utility.cxx, in place of appending `&&`, `&` and `*` to types