### PR TITLE
Simple identifiers do not require heavy parsing. NFC.

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -638,6 +638,17 @@ Cpp::TCppScope_t GetEnumFromCompleteName(const std::string &name) {
   }
   return Cpp::GetNamed(name.substr(start, end), curr_scope);
 }
+static bool is_identifier(std::string_view s) {
+  if (s.empty()) return false;
+  auto is_valid_start = [](unsigned char c) {
+    return std::isalpha(c) || c == '_';
+  };
+  auto is_valid_body = [](unsigned char c) {
+    return std::isalnum(c) || c == '_';
+  };
+  return is_valid_start(s[0]) &&
+    std::all_of(s.begin() + 1, s.end(), is_valid_body);
+};
 
 // returns true if no new type was added.
 bool Cppyy::AppendTypesSlow(const std::string& name,
@@ -645,6 +656,10 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
 
   // Add no new type if string is empty
   if (name.empty())
+    return true;
+
+  // The ast printer gave us garbage.
+  if (name == "<unnamed>")
     return true;
 
   auto replace_all = [](std::string& str, const std::string& from, const std::string& to) {
@@ -659,6 +674,22 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
 
   std::string resolved_name = name;
   replace_all(resolved_name, "std::initializer_list<", "std::vector<"); // replace initializer_list with vector
+
+  // If we have a single identifier, we don't need anything complicated.
+  // Try scoped lookup first (catches type aliases / nested types declared
+  // inside `parent`), then fall back to TU (catches typedefs declared
+  // outside the query scope, e.g. `typedef Foo Bar;` at TU consulted
+  // from a method on Foo).
+  if (is_identifier(name)) {
+    TCppType_t type = parent ? Cpp::GetType(name, parent) : nullptr;
+    if (!type)
+      type = Cpp::GetType(name);
+    if (type) {
+      types.emplace_back(type);
+      return false;
+    }
+    return true;
+  }
 
   std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
 
@@ -716,11 +747,30 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
 }
 
 Cppyy::TCppType_t Cppyy::GetType(const std::string &name, bool enable_slow_lookup /* = false */) {
+    // The ast printer gave us garbage.
+    if (name == "<unnamed>")
+      return nullptr;
     std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
-    static unsigned long long var_count = 0;
 
     if (auto type = Cpp::GetType(name))
         return type;
+
+    // Plain identifiers don't need the heavy __typeof__ trampoline:
+    // Cpp::GetType above already covers builtin types and named
+    // scopes. Exception: the three identifier-shaped C++ value-
+    // literals -- `true`, `false`, `nullptr` -- aren't reachable by
+    // name (no type called "false") but appear as non-type template
+    // args in libstdc++ types like _Node_iterator<..., false, false>;
+    // map them to their underlying type directly so the per-chunk
+    // fallback in AppendTypesSlow gets a real type without paying
+    // the trampoline cost.
+    if (is_identifier(name)) {
+      if (name == "true" || name == "false")
+        return Cpp::GetType("bool");
+      if (name == "nullptr")
+        return Cpp::GetType("nullptr_t", Cpp::GetNamed("std"));
+      return nullptr;
+    }
 
     if (!enable_slow_lookup) {
         if (name.find("::") != std::string::npos)
@@ -731,6 +781,7 @@ Cppyy::TCppType_t Cppyy::GetType(const std::string &name, bool enable_slow_looku
 
     // Here we might need to deal with integral types such as 3.14.
 
+    static unsigned long long var_count = 0;
     std::string id = "__Cppyy_GetType_" + std::to_string(var_count++);
     std::string using_clause = "using " + id + " = __typeof__(" + name + ");\n";
 

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -700,8 +700,7 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
     Cpp::Declare(code.c_str(), /*silent=*/true); // initialize the trampoline
 
   std::string var = "__Cppyy_s" + std::to_string(struct_count++);
-  // FIXME: We cannot use silent because it erases our error code from Declare!
-  if (!Cpp::Declare(("__Cppyy_AppendTypesSlow<" + resolved_name + "> " + var +";\n").c_str(), /*silent=*/false)) {
+  if (!Cpp::Declare(("__Cppyy_AppendTypesSlow<" + resolved_name + "> " + var +";\n").c_str(), /*silent=*/true)) {
     std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
     TCppType_t varN =
         Cpp::GetVariableType(Cpp::GetNamed(var.c_str(), /*parent=*/nullptr));


### PR DESCRIPTION
This patch checks if the interfaces are called with single identifiers and adds a fast path to regular CppInterOp lookup. It also checks for AST garbage that came from stringifying anonymous C++ entities.

After these changes we should consume less memory and that will make our infrastructure more stable since it won't rely on interpreter's error recovery logic when a parsing fails.