### PR TITLE
Add Cppyy::IsInteger

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -565,6 +565,16 @@ bool Cppyy::IsClassType(TCppType_t type) {
     return Cpp::IsRecordType(type);
 }
 
+bool Cppyy::IsIntegerType(TCppType_t type, bool* is_signed /*= nullptr*/) {
+  if (is_signed) {
+    Cpp::Signedness sign;
+    bool res = Cpp::IsIntegerType(type, &sign);
+    *is_signed = (sign == Cpp::Signedness::kSigned);
+    return res;
+  }
+  return Cpp::IsIntegerType(type, nullptr);
+}
+
 bool Cppyy::IsPointerType(TCppType_t type) {
     return Cpp::IsPointerType(type);
 }

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -84,6 +84,8 @@ namespace Cppyy {
     RPY_EXPORTED
     bool IsClassType(TCppType_t type);
     RPY_EXPORTED
+    bool IsIntegerType(TCppType_t type, bool* is_signed = nullptr);
+    RPY_EXPORTED
     bool IsPointerType(TCppType_t type);
     RPY_EXPORTED
     bool IsFunctionPointerType(TCppType_t type);


### PR DESCRIPTION
needed by arg match scoring interfaces for numba, and recently aliasing `size()` to `__len__` for container-like classes