### PR TITLE
Fix to rename from libclangcppinterop to libcppinterop

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -179,7 +179,7 @@ public:
         std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
         if (!Cpp::LoadDispatchAPI(
                 CPPINTEROP_DIR
-                "/lib/libclangCppInterOp" CMAKE_SHARED_LIBRARY_SUFFIX)) {
+                "/lib/libCppInterOp" CMAKE_SHARED_LIBRARY_SUFFIX)) {
             std::cerr << "[cppyy-backend] Failed to load CppInterOp" << std::endl;
             return;
         }

--- a/python/cppyy_backend/loader.py
+++ b/python/cppyy_backend/loader.py
@@ -35,7 +35,7 @@ dl = ctypes.CDLL(None)
 # Function to check if a shared object is already loaded
 def is_shared_object_loaded(lib_path):
     try:
-        # Check if somebody else has dlopen-ed libclangCppInterOp.
+        # Check if somebody else has dlopen-ed libCppInterOp.
         dl.CreateInterpreter
         return True
     except:


### PR DESCRIPTION
This PR is needed as part of CppInterOp library name change in https://github.com/compiler-research/CppInterOp/pull/882