### PR TITLE
fix: split_comma_saparated_types

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -615,14 +615,6 @@ bool split_comma_saparated_types(const std::string& name,
       break;
     }
     case '>': {
-      if (matching_angular_brackets == 1) {
-        types.push_back(
-            trim(trimed_name.substr(start_pos, end_pos - start_pos + 1)));
-        start_pos = end_pos + 1;
-      } else if (matching_angular_brackets < 1) {
-        types.clear();
-        return false;
-      }
       matching_angular_brackets--;
       break;
     }


### PR DESCRIPTION
for the cases that requires parsing after closing `>` for example:
```
  std::vector<int>::value_type
  ~~~~~~~~~~~~~~~^
```
Previously it would only parse till here and
`::value_type` would be considered as a seperate type

This change fixes it