### PR TITLE
[ci] Drop OSX 15 SDK jobs

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -22,45 +22,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: osx15-arm-clang-clang-repl-21
-            os: macos-15
+          - name: osx26-arm-clang-clang-repl-21
+            os: macos-26
             compiler: clang
             clang-runtime: '21'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
-          - name: osx15-arm-clang-clang-repl-20
-            os: macos-15
+          - name: osx26-arm-clang-clang-repl-20
+            os: macos-26
             compiler: clang
             clang-runtime: '20'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
-          - name: osx15-arm-clang-clang20-cling
-            os: macos-15
-            compiler: clang
-            clang-runtime: '20'
-            cling: On
-            cling-version: '1.3'
-            root-llvm-tag: 'cling-llvm20-20260119-01'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: osx15-x86-clang-clang-repl-21
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '21'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-          - name: osx15-x86-clang-clang-repl-20
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '20'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-          - name: osx15-x86-clang-clang20-cling
-            os: macos-15-intel
+          - name: osx26-arm-clang-clang20-cling
+            os: macos-26
             compiler: clang
             clang-runtime: '20'
             cling: On


### PR DESCRIPTION
Follow CppInterOp that dropped the older SDK versions from the CI. Numba does not work well on this old sdk