### PR TITLE
clingwrapper: expose AddTypeQualifier.

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -553,6 +553,11 @@ Cppyy::TCppType_t Cppyy::GetReferencedType(TCppType_t type, bool rvalue) {
   return Cpp::GetReferencedType(type, rvalue);
 }
 
+Cppyy::TCppType_t Cppyy::AddTypeQualifier(TCppType_t type, Cpp::QualKind qual) {
+  std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
+  return Cpp::AddTypeQualifier(type, qual);
+}
+
 bool Cppyy::IsRValueReferenceType(TCppType_t type) {
     return Cpp::GetValueKind(type) == Cpp::ValueKind::RValue;
 }

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -76,6 +76,8 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppType_t GetReferencedType(TCppType_t type, bool rvalue = false);
     RPY_EXPORTED
+    TCppType_t AddTypeQualifier(TCppType_t type, Cpp::QualKind qual);
+    RPY_EXPORTED
     std::string ResolveEnum(TCppScope_t enum_scope);
     RPY_EXPORTED
     bool IsLValueReferenceType(TCppType_t type);


### PR DESCRIPTION
The cv-qualifier triplet was already in CppInterOp's public surface (Cpp::AddTypeQualifier etc., declared by the tablegen-generated CppInterOpDecl.inc) but the cppyy-backend shim didn't re-export them as Cppyy:: wrappers. Adding "const" to a TCppType_t -- e.g. building "const T" out of GetType("T") for the canonical-QT registry in Converters.cxx -- required pulling in CppInterOp.h directly, which breaks the cppyy-backend abstraction boundary.

Add the Cppyy::AddTypeQualifier wrapper in cpp_cppyy.h + clingwrapper.cxx, mirroring the GetPointerType / GetReferencedType pattern (one-line forwarder under InterOpMutex). Only AddTypeQualifier has an in-tree caller (Converters.cxx); RemoveTypeQualifier and HasTypeQualifier are left out until a concrete caller appears -- the canonical-QT identity check is already handled by direct pointer comparison.