### PR TITLE
Read CppInterOp location from CPPINTEROP_BIN_DIR env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
 endif()
 
 target_compile_definitions(cppyy-backend PRIVATE
-  CPPINTEROP_DIR="${_interop_install_dir}"
+  CPPINTEROP_BIN_DIR="${_interop_install_dir}"
   CMAKE_SHARED_LIBRARY_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
 

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -109,15 +109,50 @@ bool is_integral(std::string& s)
         s.end(), [](unsigned char c) { return !std::isdigit(c); }) == s.end();
 }
 
+// CppInterOp artifacts prefix (the directory containing lib/ and include/):
+// the CPPINTEROP_BIN_DIR environment variable overrides the compile-time
+// default.
+static inline
+std::string cppinterop_dir()
+{
+    if (const char* env = getenv("CPPINTEROP_BIN_DIR"))
+        return env;
+#ifdef CPPINTEROP_BIN_DIR
+    return CPPINTEROP_BIN_DIR;
+#else
+    return "";
+#endif
+}
+
+static inline
+std::string cppinterop_lib_path()
+{
+    std::string dir = cppinterop_dir();
+    if (dir.empty())
+        return "";
+#ifdef CMAKE_SHARED_LIBRARY_SUFFIX
+    // CMake sets the correct per-platform suffix (.so/.dylib/.dll).
+    return dir + "/lib/libclangCppInterOp" CMAKE_SHARED_LIBRARY_SUFFIX;
+#else
+    // Non-CMake builds (no suffix defined): default to .so.
+    return dir + "/lib/libclangCppInterOp.so";
+#endif
+}
+
 class ApplicationStarter {
   Cppyy::TInterp_t Interp;
 public:
     ApplicationStarter() {
         std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
-        if (!Cpp::LoadDispatchAPI(
-                CPPINTEROP_DIR
-                "/lib/libclangCppInterOp" CMAKE_SHARED_LIBRARY_SUFFIX)) {
-            std::cerr << "[cppyy-backend] Failed to load CppInterOp" << std::endl;
+        const std::string lib_path = cppinterop_lib_path();
+        if (lib_path.empty()) {
+            std::cerr << "[cppyy-backend] CppInterOp location unknown: set the"
+                " CPPINTEROP_BIN_DIR environment variable" << std::endl;
+            return;
+        }
+        if (!Cpp::LoadDispatchAPI(lib_path.c_str())) {
+            std::cerr << "[cppyy-backend] Failed to load CppInterOp from "
+                << lib_path << std::endl;
             return;
         }
         // Check if somebody already loaded CppInterOp and created an
@@ -185,7 +220,7 @@ public:
         Cpp::AddIncludePath((ClingSrc + "/tools/cling/include").c_str());
         Cpp::AddIncludePath((ClingSrc + "/include").c_str());
         Cpp::AddIncludePath((ClingBuildDir + "/include").c_str());
-        Cpp::AddIncludePath((std::string(CPPINTEROP_DIR) + "/include").c_str());
+        Cpp::AddIncludePath((cppinterop_dir() + "/include").c_str());
         Cpp::LoadLibrary("libstdc++", /* lookup= */ true);
 
         // load frequently used headers


### PR DESCRIPTION
## Summary
- The CppInterOp install prefix was baked into a `CPPINTEROP_DIR` macro at build time, so a relocated backend could not find `libclangCppInterOp`.
- Add `cppinterop_dir()` / `cppinterop_lib_path()` helpers that prefer the `CPPINTEROP_BIN_DIR` environment variable, fall back to the compile-time default, and report a clear error (instead of relying on the macro always being defined) when the location is unknown.
- Rename the macro to `CPPINTEROP_BIN_DIR` to match.

## Test plan
- Rebuilt the cppyy stack; `test_cppyy`: 501 passed, 69 skipped, 19 xfailed, 2 xpassed.
- Verified `import cppyy` with a bogus `CPPINTEROP_BIN_DIR` prints a clear diagnostic instead of crashing.

> Note: this pairs with compiler-research/CppInterOp#1037, which introduces the same `CPPINTEROP_BIN_DIR` convention on the CppInterOp side.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)