### PR TITLE
Don't resolve pointer/reference type spellings to scopes in GetScope

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -705,6 +705,13 @@ Cppyy::TCppScope_t Cppyy::GetScope(const std::string& name,
       bool added_new_type = !Cppyy::AppendTypesSlow(name, types, /*parent=*/parent_scope);
       std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
       if (added_new_type && types.size() == 1) {
+        // A pointer or reference spelling (e.g. "std::chrono::nanoseconds *",
+        // the return type of std::array<nanoseconds, N>::begin()) does not
+        // name a scope; GetScopeFromType would silently strip the pointer and
+        // return the pointee's scope, misclassifying the name.
+        if (Cpp::IsPointerType(types[0].m_Type) ||
+            Cpp::IsReferenceType(types[0].m_Type))
+          return nullptr;
         TCppScope_t scope = Cpp::GetScopeFromType(types[0].m_Type);
         // Naming the type as a template argument above does not instantiate
         // it, so the specialization may still be declared-but-undefined.


### PR DESCRIPTION
Partial fix for compiler-research/cppyy#198 (the `std::array` iteration half).

- `GetScope`'s template branch handed pointer spellings like `std::chrono::duration<...> *` to `GetScopeFromType`, which strips the pointer and returns the pointee's scope.
- `std::array<T, N>::begin()` returns the raw pointer typedef `T*` (libstdc++), so CPyCppyy's iterator detection (`Pythonize.cxx`, generic begin/end block) saw a non-null scope and installed the STL-iterator protocol on a value proxy of `T` — iteration silently yielded zero elements (and `operator++` mutated the first element in place).
- Returning no scope for pointer/reference spellings lets the bindings fall back to index-based iteration, matching the cling-based wrapper's behavior.

Tests: `TestSTLARRAY::test05_array_of_chrono_types_should_be_iterable` is un-xfail'd in a companion cppyy PR; full cppyy suite is clean (510 passed, 0 failures).

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)