### PR TITLE
Suppress debug info on the AppendTypesSlow trampoline variable

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -541,7 +541,10 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
 
   for (const std::string& candidate : candidates) {
     std::string var = "__Cppyy_s" + std::to_string(struct_count++);
-    if (!Cpp::Declare(("__Cppyy_AppendTypesSlow<" + candidate + "> " + var + ";\n").c_str(), /*silent=*/true)) {
+    // nodebug: with -g the variable's debug info would carry the full DIE
+    // tree of every template argument (all member declarations included) --
+    // a large, uncacheable per-lookup cost on heavyweight types.
+    if (!Cpp::Declare(("__Cppyy_AppendTypesSlow<" + candidate + "> __attribute__((nodebug)) " + var + ";\n").c_str(), /*silent=*/true)) {
       TCppType_t varN =
           Cpp::GetVariableType(Cpp::GetNamed(var.c_str(), /*parent=*/nullptr));
       TCppScope_t instance_class = Cpp::GetScopeFromType(varN);


### PR DESCRIPTION
## What

Marks the `__Cppyy_AppendTypesSlow` trampoline variable `__attribute__((nodebug))`.

## Why

Since #213 ("Resolve templated type names as a whole in GetScope"), `GetScope`'s
fallback for templated names routes the whole type expression through a
`__Cppyy_AppendTypesSlow<expr> var;` declaration. When the interpreter runs with
debug info enabled (`-g` in `CPPINTEROP_EXTRA_INTERPRETER_ARGS`), each such
declaration emits the complete debug-info DIE tree of every template argument —
for a heavyweight class that is every member declaration, each becoming a uniqued
`DISubprogram` probed against the LLVMContext's ever-growing uniquing set. The
variable name is fresh on every call, so nothing is cached and the cost is paid
per failed templated-name lookup.

On a large real-world workload (market-data replay JIT-compiling large headers,
`-ggdb3`), this regressed wall clock ~8.5x (162s → 1378s); a profile showed >90%
of CPU in `DenseMap<DISubprogram*, ...>` probe/insert inside the JIT. The previous
split-and-`InstantiateTemplate` path was Sema-only and never paid codegen or debug
info. With the trampoline variable marked `nodebug`, the workload returns to 137s —
faster than before the GetScope rework — while user code keeps full debug info and
the whole-expression resolution semantics are unchanged.

The trampoline exists only to be reflected on via `GetVariableType`, so its debug
info carries no value.

`test_templates.py` / `test_stltypes.py` / `test_datatypes.py` / `test_regression.py`
pass with the change (they exercise `AppendTypesSlow` through templated lookups).

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)
