### PR TITLE
Pass names of non-type entities through as template arg values

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -107,7 +107,9 @@ bool is_integral(std::string& s)
 {
     if (s == "false") { s = "0"; return true; }
     else if (s == "true") { s = "1"; return true; }
-    return !s.empty() && std::find_if(s.begin(), 
+    // allow a leading minus (negative literal)
+    auto begin = s.begin() + (s.size() > 1 && s[0] == '-' ? 1 : 0);
+    return !s.empty() && std::find_if(begin,
         s.end(), [](unsigned char c) { return !std::isdigit(c); }) == s.end();
 }
 
@@ -513,6 +515,11 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
   // outside the query scope, e.g. `typedef Foo Bar;` at TU consulted
   // from a method on Foo).
   if (is_identifier(name)) {
+    // true/false are identifier-shaped value literals.
+    if (name == "true" || name == "false") {
+      types.emplace_back(Cpp::GetType("bool").data, name == "true" ? "1" : "0");
+      return false;
+    }
     // Non-type entity (variable, enum constant): pass its name; Sema needs an
     // expression, not the entity's type.
     TCppScope_t named = parent ? Cpp::GetNamed(name, parent) : nullptr;
@@ -520,6 +527,12 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
       named = Cpp::GetNamed(name);
     if (named && (Cpp::IsVariable(named) || Cpp::IsEnumConstant(named))) {
       types.emplace_back(Cpp::GetTypeFromScope(named).data,
+                         strdup(Cpp::GetQualifiedCompleteName(named).c_str()));
+      return false;
+    }
+    // Template name (template-template arg): no type; carried by name.
+    if (named && Cpp::IsTemplate(named)) {
+      types.emplace_back(nullptr,
                          strdup(Cpp::GetQualifiedCompleteName(named).c_str()));
       return false;
     }
@@ -584,6 +597,14 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
     }
 
     if (!type) {
+      // Qualified template name (template-template arg).
+      if (TCppScope_t named = GetEnumFromCompleteName(i)) {
+        if (Cpp::IsTemplate(named)) {
+          types.emplace_back(
+              nullptr, strdup(Cpp::GetQualifiedCompleteName(named).c_str()));
+          continue;
+        }
+      }
       types.clear();
       return true;
     }

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -513,6 +513,16 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
   // outside the query scope, e.g. `typedef Foo Bar;` at TU consulted
   // from a method on Foo).
   if (is_identifier(name)) {
+    // Non-type entity (variable, enum constant): pass its name; Sema needs an
+    // expression, not the entity's type.
+    TCppScope_t named = parent ? Cpp::GetNamed(name, parent) : nullptr;
+    if (!named)
+      named = Cpp::GetNamed(name);
+    if (named && (Cpp::IsVariable(named) || Cpp::IsEnumConstant(named))) {
+      types.emplace_back(Cpp::GetTypeFromScope(named).data,
+                         strdup(Cpp::GetQualifiedCompleteName(named).c_str()));
+      return false;
+    }
     TCppType_t type = parent ? Cpp::GetType(name, parent) : nullptr;
     if (!type)
       type = Cpp::GetType(name);
@@ -580,10 +590,14 @@ bool Cppyy::AppendTypesSlow(const std::string& name,
 
     if (is_integral(i))
         integral_value = strdup(i.c_str());
-    if (TCppScope_t scope = GetEnumFromCompleteName(i))
+    if (TCppScope_t scope = GetEnumFromCompleteName(i)) {
       if (Cpp::IsEnumConstant(scope))
         integral_value =
             strdup(std::to_string(Cpp::GetEnumConstantValue(scope)).c_str());
+      // Variable: a non-type argument; pass its name (see identifier path).
+      else if (Cpp::IsVariable(scope))
+        integral_value = strdup(Cpp::GetQualifiedCompleteName(scope).c_str());
+    }
     types.emplace_back(type.data, integral_value);
   }
   return false;


### PR DESCRIPTION
A string template argument naming a constexpr variable or enum constant resolves to the *entity's type* today: `AppendTypesSlow`'s identifier path calls `Cpp::GetType`, whose `ValueDecl` branch returns the variable's declared type with no value. Sema then sees a type argument for a non-type parameter and rejects the instantiation ("template argument for non-type template parameter must be an expression"):

```python
cppyy.cppdef("template <int N> class C {}; constexpr int IntArg = 42;")
cppyy.gbl.C["IntArg"]   # TypeError (worked on cling-based cppyy)
```

This PR checks `Cpp::GetNamed` first: when the identifier names a variable or enum constant, it emits `TemplateArgInfo{entity type, strdup(GetQualifiedCompleteName(...))}` so the instantiation refers to the entity instead of its type. The comma-split fallback gets the symmetric check, covering qualified spellings ("ns::Val") and multi-argument strings. It also passes class/alias template names through as template-template arguments (null type + qualified name), and fixes `true`/`false` and negative integer literals in the identifier path (both previously produced a type-only argument that Sema rejected).

Requires the companion PR compiler-research/CppInterOp#1074, which teaches `InstantiateTemplate` / `BestOverloadFunctionMatch` to resolve a non-numeric `m_IntegralValue` as a named constant entity (DeclRefExpr, converted by Sema like a written argument). Notes for the FIXME discussion at https://github.com/compiler-research/cppyy-backend/pull/137#discussion_r2079357491 : this narrows the string-parsing surface rather than growing it — names are resolved through lookup, not parsed.

Intentionally out of scope: arbitrary constant expressions in strings ("IntArg + 1", "&x") — only (possibly qualified) names of constant entities and templates. cppyy `TemplateProxy` objects as template-template arguments now fail with a clean TypeError (previously a segfault via a null-type `IsEnumType` call); making them *work* needs a CPyCppyy `AddTypeName` change — left as follow-up.

Tests: the conversion logic is unit-tested in the companion CppInterOp PR (`ScopeReflection_InstantiateTemplateNamedNTTPArg`); end-to-end coverage in our downstream suite (class templates, function-template explicit args, enum constants, qualified names, `const char*` array decay). Happy to add a `test_templates.py` case to compiler-research/cppyy alongside if preferred.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)
